### PR TITLE
Updates to the latest version of miniconda

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -11,12 +11,12 @@ pre-package = "./scripts/build.sh"
 [[metadata.dependencies]]
 id = "miniconda3"
 name = "Miniconda"
-sha256 = "a23fcffe97690d3bbcd34cda798c3a3318e0f35d863c5d4aca3fc983fe8450b7"
-source = "https://github.com/conda/conda/archive/4.7.12.tar.gz"
-source_sha256 = "a23fcffe97690d3bbcd34cda798c3a3318e0f35d863c5d4aca3fc983fe8450b7"
+sha256 = "536817d1b14cb1ada88900f5be51ce0a5e042bae178b5550e62f61e223deae7c"
+source = "https://github.com/conda/conda/archive/4.9.2.tar.gz"
+source_sha256 = "d7f946e5c770e45da8961323ca96399bf1a881eb68bbaecc7cb1e249f5c86d54"
 stacks = ["io.buildpacks.stacks.bionic","org.cloudfoundry.stacks.cflinuxfs3"]
-uri = "https://repo.continuum.io/miniconda/Miniconda3-4.7.12-Linux-x86_64.sh"
-version = "4.7.12"
+uri = "https://repo.anaconda.com/miniconda/Miniconda3-py39_4.9.2-Linux-x86_64.sh"
+version = "4.9.2"
 
 [[metadata.dependency_deprecation_dates]]
 date = 2023-06-27T00:00:00Z

--- a/integration/init_test.go
+++ b/integration/init_test.go
@@ -72,7 +72,7 @@ func TestIntegration(t *testing.T) {
 
 	SetDefaultEventuallyTimeout(10 * time.Second)
 
-	suite := spec.New("Integration", spec.Report(report.Terminal{}), spec.Sequential())
+	suite := spec.New("Integration", spec.Report(report.Terminal{}), spec.Parallel())
 	suite("Default", testDefault)
 	suite("Logging", testLogging)
 	suite("LayerReuse", testReusingLayerRebuild)


### PR DESCRIPTION
- Makes integration suite run in parallel again to see if latest
miniconda version fixes hanging issue.

Resolves #96
Resolves #102 