### PR TITLE
Readme: Vendoring instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ can use to build your app as follows:
 Follow these steps to vendor python packages in your app using conda
 
 **Prerequisites**
-- Must be run on linux OS and **case-insensitive file system**
+- Must be run on linux OS and **case-sensitive file system**
 - Install conda build tools: `conda install conda-build`
 
 **Steps**


### PR DESCRIPTION
It looks like this could have been a typo.
Vendoring worked on a linux case-sensitive system
but failed with error on a mac case-insensitive system
when the team tried it. cc @fg-j